### PR TITLE
Actually fix Switch Compression, fixes #9

### DIFF
--- a/HGPAKTool/hgpaktool.py
+++ b/HGPAKTool/hgpaktool.py
@@ -863,8 +863,8 @@ if __name__ == '__main__':
             sys.exit(1)
     elif plat == Platform.SWITCH:
         # Decompressed chunk size on switch is 128kb
-        DECOMPRESSED_CHUNK_SIZE_SWITCH = 0x20000
-        CLEAN_BYTES_S = b"\x00" * DECOMPRESSED_CHUNK_SIZE_SWITCH
+        DECOMPRESSED_CHUNK_SIZE = 0x20000
+        CLEAN_BYTES_S = b"\x00" * DECOMPRESSED_CHUNK_SIZE
 
     compressor = Compressor(plat)
 

--- a/HGPAKTool/hgpaktool.py
+++ b/HGPAKTool/hgpaktool.py
@@ -864,7 +864,7 @@ if __name__ == '__main__':
     elif plat == Platform.SWITCH:
         # Decompressed chunk size on switch is 128kb
         DECOMPRESSED_CHUNK_SIZE = 0x20000
-        CLEAN_BYTES_S = b"\x00" * DECOMPRESSED_CHUNK_SIZE
+        CLEAN_BYTES = b"\x00" * DECOMPRESSED_CHUNK_SIZE
 
     compressor = Compressor(plat)
 


### PR DESCRIPTION
DECOMPRESSED_CHUNK_SIZE_SWITCH and CLEAN_BYTES_S are not used anywhere, causing compression to fall back to the old behavior causing Oodle to assume the data is corrupt.